### PR TITLE
Fix MemoryLeakFix bugs in mod mixins

### DIFF
--- a/config/archaicfix.cfg
+++ b/config/archaicfix.cfg
@@ -13,11 +13,23 @@ general {
     # EXPERIMENTAL: Cache matching crafting recipes to avoid needing to scan the whole list each time. [default: false]
     B:cacheRecipes=false
 
-    # Clean up LaunchClassLoader cache. [default: true]
-    B:clearLaunchLoaderCache=true
+    # Disable completely the crash report from archaicfix [default: false]
+    B:disableCrashReport=false
+
+    # Caches the blockstates of the world, fixing large frametime spikes when blocks are placed or broken. [default: true]
+    B:enableBlockstateCache=true
 
     # Force all mixins to be loaded and the cache to be cleared. This saves RAM, but may reveal bugs in mods' mixin configs. Based on MemoryLeakFix. [default: false]
-    B:clearMixinCache=false
+    B:forceClearMixinCache=false
+
+    # Force FML to clear the untransformed class cache. Based on MemoryLeakFix. [default: true]
+    B:forceClearUntransformedClassCache=true
+
+    # Hide missing block/item mapping warnings [default: true]
+    B:hideMissingMappingWarnings=true
+
+    # Re-implements OptiFine's ItemRenderer mixins without breaking compatibility with other mods. [default: true]
+    B:itemRendererFix=true
 
     # Disable NEI item rendering in AE2 to fix duplicate stack size rendering when using AE2 rv3-beta-6 with NEI > 2.6.37-GTNH [default: false]
     B:disableAE2NEIItemRendering=false

--- a/config/mixingasm/transformer_inclusion_list.txt
+++ b/config/mixingasm/transformer_inclusion_list.txt
@@ -4,3 +4,6 @@
 
 
 # --- Additional trusted transformers ---
+org.embeddedt.*
+com.gtnewhorizons.*
+com.falsepattern.*


### PR DESCRIPTION
Addresses mixin loading bugs in ArchaicFix by updating its configuration to match the expected schema and enhancing the trusted transformer list in Mixingasm to ensure a stable environment when RAM-saving cache clearing is used.

---
*PR created automatically by Jules for task [8692315302694971353](https://jules.google.com/task/8692315302694971353) started by @Rerserder*